### PR TITLE
Update http.go

### DIFF
--- a/pkg/input/http.go
+++ b/pkg/input/http.go
@@ -108,11 +108,13 @@ func (h *HTTPInput) ServeHTTP(writer http.ResponseWriter, req *http.Request) {
 	if req.Method == "GET" || req.Method == "HEAD" {
 		writer.WriteHeader(http.StatusOK)
 		return
+	} else if req.Method == "POST" {
+		if !h.authenticate(writer, req) {
+			return
+		}
 	}
 
-	if !h.authenticate(writer, req) {
-		return
-	}
+
 
 	msgs, err := h.readMessages(req)
 	if err != nil {


### PR DESCRIPTION
Ajax post message will send two message:
1、options，without base authentication，and will get 401 error code when requesting。
2、POST，with base authentication

to fix the problem，and will authenticate only on "POST" Method